### PR TITLE
Add `adriankarlen/bar.wezterm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## Tab bar
 
-- [adriankarlen/bar.wezterm](https://github.com/adriankarlen/bar.wezterm) - A configurable tab bar with batteries included
+- [adriankarlen/bar.wezterm](https://github.com/adriankarlen/bar.wezterm) - A configurable tab bar with batteries included.
 - [michaelbrusegard/tabline.wez](https://github.com/michaelbrusegard/tabline.wez) - A versatile and easy to use retro tab bar with the `lualine.nvim` configuration format.
 - [yriveiro/wezterm-status](https://github.com/yriveiro/wezterm-status) - Configurable status for the retro tab bar.
 - [yriveiro/wezterm-tabs](https://github.com/yriveiro/wezterm-tabs) - Configurable tabs for the retro tab bar.


### PR DESCRIPTION
### Repo URL

https://github.com/adriankarlen/bar.wezterm

### Checklist

- [X] The plugin is specifically built for WezTerm.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [X] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [X] The description doesn't contain emojis.
- [X] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `WezTerm`), Lua is spelled as `Lua` (capitalized).
- [X] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
