### PR TITLE
Add `winter-again/wezterm-config.nvim`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ### Checklist
 
-- [ ] The plugin is specifically built for WezTerm.
+- [ ] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
 - [ ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
 - [ ] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
 - [ ] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 
 - [xarvex/presentation.wez](https://github.com/xarvex/presentation.wez) - Rather simple presentation mode toggle.
 
+## Neovim
+
+- [winter-again/wezterm-config.nvim](https://github.com/winter-again/wezterm-config.nvim) - Interact with the WezTerm configuration directly from Neovim.
+
 ## Session
 
 - [MLFlexer/resurrect.wezterm](https://github.com/MLFlexer/resurrect.wezterm) - Save and restore the state of windows, tabs and panes.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - [Keybinding](#keybinding)
 - [Media](#media)
+- [Neovim](#neovim)
 - [Session](#session)
 - [Tab bar](#tab-bar)
 - [Utility](#utility)


### PR DESCRIPTION
### Repo URL

https://github.com/winter-again/wezterm-config.nvim

### Checklist

- [x] The plugin is specifically built for WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `WezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
