### PR TITLE
Add `justinsgithub/wezterm-types`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 [WezTerm](https://wezfurlong.org/wezterm/) is a powerful cross-platform terminal emulator and multiplexer written by [@wez](https://github.com/wez) and implemented in [Rust](https://www.rust-lang.org).
 
+To enhance your WezTerm configuration experience:
+- [justinsgithub/wezterm-types](https://github.com/justinsgithub/wezterm-types) - WezTerm types that can be added as a completion source in your editor to provide code assistance when working with WezTerm's Lua API.
+
 ## Contents
 
 - [Keybinding](#keybinding)
@@ -31,7 +34,6 @@
 
 - [mrjones2014/smart-splits.nvim](https://github.com/mrjones2014/smart-splits.nvim) - Provides an addon for seamless pane navigation between Neovim and the WezTerm MUX.
 - [winter-again/wezterm-config.nvim](https://github.com/winter-again/wezterm-config.nvim) - Interact with the WezTerm configuration directly from Neovim.
-- [justinsgithub/wezterm-types](https://github.com/justinsgithub/wezterm-types) - WezTerm types that can be added as a completion source.
 
 ## Session
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 
 - [mrjones2014/smart-splits.nvim](https://github.com/mrjones2014/smart-splits.nvim) - Provides an addon for seamless pane navigation between Neovim and the WezTerm MUX.
 - [winter-again/wezterm-config.nvim](https://github.com/winter-again/wezterm-config.nvim) - Interact with the WezTerm configuration directly from Neovim.
+- [justinsgithub/wezterm-types](https://github.com/justinsgithub/wezterm-types) - WezTerm types that can be added as a completion source.
 
 ## Session
 


### PR DESCRIPTION
### Repo URL

https://github.com/justinsgithub/wezterm-types

### Checklist

- [ ] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `WezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.

It's not quite a WezTerm plugin, but it makes configuring/writing plugins for WezTerm a lot easier since you get type information of the WezTerm API as a completion source.

It can be added easily within nvim using [folke/lazydev.nvim](https://github.com/folke/lazydev.nvim) with:
```lua
  { 'justinsgithub/wezterm-types', ft = 'lua' },
  {
    'folke/lazydev.nvim',
    ft = 'lua',
    opts = {
      library = {
        { path = 'wezterm-types/types', mods = { 'wezterm' } },
      },
    },
  },
