### PR TITLE
Add `rootiest/battery.wez`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [WezTerm](https://wezfurlong.org/wezterm/) is a powerful cross-platform terminal emulator and multiplexer written by [@wez](https://github.com/wez) and implemented in [Rust](https://www.rust-lang.org).
 
 To enhance your WezTerm configuration experience:
+
 - [justinsgithub/wezterm-types](https://github.com/justinsgithub/wezterm-types) - WezTerm types that can be added as a completion source in your editor to provide code assistance when working with WezTerm's Lua API.
 
 ## Contents
@@ -45,6 +46,7 @@ To enhance your WezTerm configuration experience:
 
 - [adriankarlen/bar.wezterm](https://github.com/adriankarlen/bar.wezterm) - A configurable tab bar with batteries included.
 - [michaelbrusegard/tabline.wez](https://github.com/michaelbrusegard/tabline.wez) - A versatile and easy to use retro tab bar with the `lualine.nvim` configuration format.
+- [rootiest/battery.wez](https://github.com/rootiest/battery.wez) - A colorful and fancy battery component for the retro tab bar.
 - [yriveiro/wezterm-status](https://github.com/yriveiro/wezterm-status) - Configurable status for the retro tab bar.
 - [yriveiro/wezterm-tabs](https://github.com/yriveiro/wezterm-tabs) - Configurable tabs for the retro tab bar.
 


### PR DESCRIPTION
### Repo URL

https://github.com/rootiest/battery.wez

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `WezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
