### PR TITLE
Add `lilaqua/tunicodes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ To enhance your WezTerm configuration experience:
 ## Utility
 
 - [aureolebigben/wezterm-cmd-sender](https://github.com/aureolebigben/wezterm-cmd-sender) - Send commands to multiple panes.
+- [lilaqua/tunicodes](https://gitlab.com/lilaqua/tunicodes) - Insert Unicode characters via their codepoints.


### PR DESCRIPTION
### Repo URL

https://gitlab.com/lilaqua/tunicodes

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `wezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
