### PR TITLE
Update wezterm-types repo URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 To enhance your WezTerm configuration experience:
 
-- [justinsgithub/wezterm-types](https://github.com/justinsgithub/wezterm-types) - WezTerm types that can be added as a completion source in your editor to provide code assistance when working with WezTerm's Lua API.
+- [DrKJeff16/wezterm-types](https://github.com/DrKJeff16/wezterm-types) - WezTerm types that can be added as a completion source in your editor to provide code assistance when working with WezTerm's Lua API.
 
 ## Contents
 


### PR DESCRIPTION
wezterm-types is under new ownership, many improvments have been made.

@DrKJeff16