### PR TITLE
Add `dimao/ai-commander.wezterm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To enhance your WezTerm configuration experience:
 ## AI
 
 - [Michal1993r/ai-helper.wezterm](https://github.com/Michal1993r/ai-helper.wezterm/tree/master) - Ask AI for CLI help with LM Studio or Google Gemini.
+- [dimao/ai-commander.wezterm](https://github.com/dimao/ai-commander.wezterm) - Generate and select bash commands based on natural language prompts.
 
 ## Keybinding
 


### PR DESCRIPTION
### Repo URL

[https://github.com/dimao/ai-commander.wezterm](https://github.com/dimao/ai-commander.wezterm)

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `wezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
