### PR TITLE
Add `sravioli/sigil.wz`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,6 @@ To enhance your WezTerm configuration experience:
 - [quantonganh/quickselect.wezterm](https://github.com/quantonganh/quickselect.wezterm) - Jump to the build error by opening them in Helix.
 - [sravioli/log.wz](https://github.com/sravioli/log.wz) - Tagged logging library with pluggable sinks and severity thresholds.
 - [sravioli/memo.wz](https://github.com/sravioli/memo.wz) - Memoization, caching, and persistent state management.
+- [sravioli/sigil.wz](https://github.com/sravioli/sigil.wz) - Icon and identity-color registry for processes, tools, and UI labels.
 - [sravioli/warp.wz](https://github.com/sravioli/warp.wz) - General-purpose utility library with string, table, list, path, and filesystem helpers.
 - [btrachey/wezterm-replay](https://github.com/btrachey/wezterm-replay) - Parse command output and get URLs, shell commands, etc. pasted into your next prompt.


### PR DESCRIPTION
### Repo URL

<https://github.com/sravioli/sigil.wz>

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `wezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
