### PR TITLE
Add `M-Marbouh/agent-quota.wezterm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To enhance your WezTerm configuration experience:
 - [dimao/ai-commander.wezterm](https://github.com/dimao/ai-commander.wezterm) - Generate and select bash commands based on natural language prompts.
 - [EdenGibson/wezterm-quota-limit](https://github.com/EdenGibson/wezterm-quota-limit) - Shows Claude API usage quota in the status bar with color-coded thresholds and automatic token refresh.
 - [Eric162/wezterm-agent-deck](https://github.com/Eric162/wezterm-agent-deck) - Monitors AI coding agents, shows status dots in tabs and notifications when agents need attention.
+- [M-Marbouh/agent-quota.wezterm](https://github.com/M-Marbouh/agent-quota.wezterm) - Shows Claude and Codex quota usage in the status bar with reset countdowns, process-aware states, and shared caching.
 
 ## Keybinding
 


### PR DESCRIPTION
Adds agent-quota.wezterm to the AI section.

This is distinct from the existing Claude-only quota plugin because it shows both Claude and Codex quota usage, includes reset countdowns, process-aware states, shared cross-window caching, and bundled Codex helper discovery.

Validation:
- Ran `npx awesome-lint`; it failed locally on `remark-lint:awesome-github` with “Awesome list must reside in a valid git repository” in the temporary clone environment, not on the added entry text.