### PR TITLE
Add `dfsramos/wezterm-sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To enhance your WezTerm configuration experience:
 - [ChrisGVE/dev.wezterm](https://github.com/ChrisGVE/dev.wezterm) - Location resolver for development and deployment of a plugin.
 - [ChrisGVE/lib.wezterm](https://github.com/ChrisGVE/lib.wezterm) - A library of common utility functions for plugin developers.
 - [ChrisGVE/listeners.wezterm](https://github.com/ChrisGVE/listeners.wezterm) - Enables enhanced event listener capabilities with persistent state management.
+- [dfsramos/wezterm-sync](https://github.com/dfsramos/wezterm-sync) - Sync your config across machines via a private GitHub Gist, with zero external dependencies.
 - [lilaqua/tunicodes](https://gitlab.com/lilaqua/tunicodes) - Insert Unicode characters via their codepoints.
 - [zsh-sage/toggle_terminal.wez](https://github.com/zsh-sage/toggle_terminal.wez) - An easy-to-use toggleable terminal window.
 - [quantonganh/quickselect.wezterm](https://github.com/quantonganh/quickselect.wezterm) - Jump to the build error by opening them in Helix.


### PR DESCRIPTION
## What

Adds [`dfsramos/wezterm-sync`](https://github.com/dfsramos/wezterm-sync) to the **Utility** section.

## Description

A plugin that syncs your `wezterm.lua` config across machines via a private GitHub Gist. On first push it prompts for a GitHub token (gist scope), creates the Gist automatically, and saves the ID locally. On a new machine, a minimal 3-line bootstrap config + Pull restores everything.

**Key detail:** implemented entirely in Lua with no external dependencies beyond `curl` (built-in on Windows 10+, macOS, and virtually all Linux distros) — no Python, no bash, no WSL required.