### PR TITLE
Add `willytop8/Wezterm-Window-Tint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To enhance your WezTerm configuration experience:
 - [neapsix/wezterm](https://github.com/neapsix/wezterm) - Rosé Pine theme, all natural pine, faux fur and a bit of soho vibes.
 - [sravioli/kanagawa.wz](https://github.com/sravioli/kanagawa.wz) - Kanagawa.nvim color schemes with Wave, Dragon, and Lotus variants.
 - [koh-sh/wezterm-theme-rotator](https://github.com/koh-sh/wezterm-theme-rotator) - Cycle through built-in themes using keyboard shortcuts.
+- [willytop8/Wezterm-Window-Tint](https://github.com/willytop8/Wezterm-Window-Tint) - Color the window frame, tab bar, and status badge by the active pane's Git root.
 
 ## Utility
 


### PR DESCRIPTION
### Repo URL

https://github.com/willytop8/Wezterm-Window-Tint

### Summary

Adds WezTerm Window Tint to the Themes section. It colors the window frame,
tab bar, and status badge from the active pane's Git root.

### Checklist

- [x] The entry is specifically built for WezTerm.
- [x] The line ends with a period.
- [x] The PR title follows `Add username/repo`.
- [x] The entry description avoids unnecessary "plugin" or "for WezTerm" wording.
- [x] The description does not contain emojis.
- [x] WezTerm and Lua capitalization is correct.
- [x] Acronyms are capitalized where used.
