### PR TITLE
Add `annie444/sync-panes.wez`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To enhance your WezTerm configuration experience:
 - [sei40kr/wez-tmux](https://github.com/sei40kr/wez-tmux) - Ported tmux keybindings.
 - [selectnull/pinned-tabs.wezterm](https://github.com/selectnull/pinned-tabs.wezterm) - Lets you assign a key binding to a specific tab.
 - [abidibo/wezterm-cmdpicker](https://github.com/abidibo/wezterm-cmdpicker) - Add a command-palette-style fuzzy picker for keybindings. Press a trigger key to search and execute any keybinding — user-defined, config, or WezTerm defaults.
+- [annie444/sync-panes.wez](https://github.com/annie444/sync-panes.wez) - Mirrors your keystrokes to every pane in the active tab — the equivalent of tmux's synchronize-panes.
 
 ## Media
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To enhance your WezTerm configuration experience:
 - [sei40kr/wez-tmux](https://github.com/sei40kr/wez-tmux) - Ported tmux keybindings.
 - [selectnull/pinned-tabs.wezterm](https://github.com/selectnull/pinned-tabs.wezterm) - Lets you assign a key binding to a specific tab.
 - [abidibo/wezterm-cmdpicker](https://github.com/abidibo/wezterm-cmdpicker) - Add a command-palette-style fuzzy picker for keybindings. Press a trigger key to search and execute any keybinding — user-defined, config, or WezTerm defaults.
-- [annie444/sync-panes.wez](https://github.com/annie444/sync-panes.wez) - Mirrors your keystrokes to every pane in the active tab — the equivalent of tmux's synchronize-panes.
+- [annie444/sync-panes.wez](https://github.com/annie444/sync-panes.wez) - Mirrors your keystrokes to every pane in the active tab — the equivalent of tmux's `synchronize-panes`.
 
 ## Media
 


### PR DESCRIPTION
### Repo URL

https://github.com/annie444/sync-panes.wez

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `wezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
