### PR TITLE
Add `usrivastava92/widgets.wez`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ To enhance your WezTerm configuration experience:
 - [sravioli/sigil.wz](https://github.com/sravioli/sigil.wz) - Icon and identity-color registry for processes, tools, and UI labels.
 - [sravioli/warp.wz](https://github.com/sravioli/warp.wz) - General-purpose utility library with string, table, list, path, and filesystem helpers.
 - [btrachey/wezterm-replay](https://github.com/btrachey/wezterm-replay) - Parse command output and get URLs, shell commands, etc. pasted into your next prompt.
+- [usrivastava92/widgets.wez](https://github.com/usrivastava92/widgets.wez) - Cross-platform status bar widgets for CPU, RAM, battery, network, and disk on macOS, Linux, and Windows.


### PR DESCRIPTION
### Repo URL

https://github.com/usrivastava92/widgets.wez

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description does not mention that it is a WezTerm plugin, it is obvious from the rest of the document. No mentions of the word `plugin` unless it is related to something else. No `.. for WezTerm`.
- [x] The description does not contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `wezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
