### PR TITLE
Add `KawaiiSelbst/keys_bypass.wez`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To enhance your WezTerm configuration experience:
 - [selectnull/pinned-tabs.wezterm](https://github.com/selectnull/pinned-tabs.wezterm) - Lets you assign a key binding to a specific tab.
 - [abidibo/wezterm-cmdpicker](https://github.com/abidibo/wezterm-cmdpicker) - Add a command-palette-style fuzzy picker for keybindings. Press a trigger key to search and execute any keybinding — user-defined, config, or WezTerm defaults.
 - [annie444/sync-panes.wez](https://github.com/annie444/sync-panes.wez) - Mirrors your keystrokes to every pane in the active tab — the equivalent of tmux's `synchronize-panes`.
+- [KawaiiSelbst/keys_bypass.wez](https://github.com/KawaiiSelbst/keys_bypass.wez) - Bypasses WezTerm shortcuts to send keys to the foreground process (e.g., Zellij or tmux). 
 
 ## Media
 


### PR DESCRIPTION
Added a new plugin for bypassing keyboard shortcuts.

### Repo URL

https://github.com/KawaiiSelbst/keys_bypass.wez

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `wezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.
