### PR TITLE
Add `KawaiiSelbst/nu_utf8_hack.wez`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To enhance your WezTerm configuration experience:
 - [selectnull/pinned-tabs.wezterm](https://github.com/selectnull/pinned-tabs.wezterm) - Lets you assign a key binding to a specific tab.
 - [abidibo/wezterm-cmdpicker](https://github.com/abidibo/wezterm-cmdpicker) - Add a command-palette-style fuzzy picker for keybindings. Press a trigger key to search and execute any keybinding — user-defined, config, or WezTerm defaults.
 - [annie444/sync-panes.wez](https://github.com/annie444/sync-panes.wez) - Mirrors your keystrokes to every pane in the active tab — the equivalent of tmux's `synchronize-panes`.
+- [KawaiiSelbst/nu_utf8_hack.wez](https://github.com/KawaiiSelbst/nu_utf8_hack.wez) - Rough hack for correct handling utf8 symbols with `SHIFT` key with `kitty-keyboard-protocol` for users of nushell.
 
 ## Media
 


### PR DESCRIPTION
### Repo URL

https://github.com/KawaiiSelbst/nu_utf8_hack.wez

### Checklist

- [x] The plugin is specifically built for WezTerm. It is okay if it has a Neovim counterpart, if it has a part specifically built for being installed in WezTerm.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ``Add/Update/Remove `username/repo` `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.
- [x] The description doesn't mention that it's a WezTerm plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for WezTerm`.
- [x] The description doesn't contain emojis.
- [x] WezTerm is spelled as `WezTerm` (not `wez`, `wezterm` or `wezTerm`), Lua is spelled as `Lua` (capitalized).
- [x] Acronyms should be fully capitalized, for example `SSH`, `TS`, `YAML`, etc.

P.S. I dunno if anybody really need it, i made it for myself some time ago. Its ok to reject.